### PR TITLE
[add] lex num (Parser.STR)

### DIFF
--- a/lexer.mll
+++ b/lexer.mll
@@ -1,10 +1,12 @@
+let num = ['0'-'9']
+
 rule main = parse
 | ' ' { main lexbuf }
 | '(' { Parser.LPAREN }
 | ')' { Parser.RPAREN }
 | '.' { Parser.DOT }
 | '\\' { Parser.LAMBDA }
-| ['a'-'z']+ as id {
+| (['a'-'z'] | num)+ as id {
   Parser.STR(id)
 }
 | '=' { Parser.EQUAL }


### PR DESCRIPTION
Parser.STRが数字も許容してくれると,Church数とか構成するときに
`c0 = \s.\z.z`
とか出来て嬉しいので追加した.